### PR TITLE
fix(conferences): adding durationInFrames in template

### DIFF
--- a/pages/conferences/[conferenceName].tsx
+++ b/pages/conferences/[conferenceName].tsx
@@ -36,6 +36,7 @@ interface TalkTemplate {
 	width: number;
 	height: number;
 	compositionName: string;
+	durationInFrames: number;
 }
 
 const Template: Record<string, TalkTemplate> = {
@@ -44,30 +45,35 @@ const Template: Record<string, TalkTemplate> = {
 		component: Devoxx2023,
 		width: 1280,
 		height: 720,
+		durationInFrames: 300,
 	},
 	Mixit: {
 		compositionName: 'Mixit2023',
 		component: MixitIntroTalk,
 		width: 1280,
 		height: 720,
+		durationInFrames: 150,
 	},
 	Snowcamp: {
 		compositionName: 'Snowcamp',
 		component: Snowcamp,
 		width: 1280,
 		height: 720,
+		durationInFrames: 150,
 	},
 	TouraineTech: {
 		compositionName: 'TouraineTech2023',
 		component: TouraineTech2023,
 		width: 1280,
 		height: 720,
+		durationInFrames: 150,
 	},
 	VeryTechTrip: {
 		compositionName: 'VeryTechTrip',
 		component: VeryTechTrip,
 		width: 720,
 		height: 720,
+		durationInFrames: 150,
 	},
 };
 const Conference: React.FC<{conference: string}> = ({conference}) => {
@@ -102,7 +108,7 @@ const Conference: React.FC<{conference: string}> = ({conference}) => {
 						width: '800px',
 						height: '450px',
 					}}
-					durationInFrames={120}
+					durationInFrames={currentTemplate.durationInFrames}
 					compositionWidth={currentTemplate.width}
 					compositionHeight={currentTemplate.height}
 					fps={30}

--- a/src/conference/mixit2023/Speakers.tsx
+++ b/src/conference/mixit2023/Speakers.tsx
@@ -20,6 +20,7 @@ export const Speakers: React.FC<{speakers: Speaker[]}> = ({speakers}) => {
 
 					return (
 						<div
+							key={speaker.name}
 							style={{
 								display: 'flex',
 								flexDirection: 'column',
@@ -27,7 +28,6 @@ export const Speakers: React.FC<{speakers: Speaker[]}> = ({speakers}) => {
 							}}
 						>
 							<TalkSpeakerPicture
-								key={speaker.name}
 								style={{
 									display: 'block',
 									position: 'relative',


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

Not all videos will have the same length, but we want a correct display on the Next application

## 🧑‍🔬 How did you make them?

Adding a `durationInFrames` parameter 🥳 

(We could have put a default value but I don't know if it's useful knowing that it depends on the video)

## 🧪 How to check them?

Check the preview, you should see the entire Devoxx video !
