### PR TITLE
feat(conference): add alpescraft video to webpage

### DIFF
--- a/pages/conferences/[conferenceName].tsx
+++ b/pages/conferences/[conferenceName].tsx
@@ -11,6 +11,7 @@ import JSONInput from 'react-json-editor-ajrm';
 import locale from 'react-json-editor-ajrm/locale/en';
 import {useState} from 'react';
 import {Code} from '../../src/components/Code';
+import {AlpesCraft} from '../../src/conference/alpescraft/AlpesCraft';
 
 const sampleData: TouraineTechProps = {
 	title: "Remotion : le 7ème art à portée de composants web et d'API 🎬",
@@ -74,6 +75,12 @@ const Template: Record<string, TalkTemplate> = {
 		width: 720,
 		height: 720,
 		durationInFrames: 150,
+	},
+	AlpesCraft: {
+		compositionName: 'AlpesCraft',
+		component: AlpesCraft,
+		width: 1280,
+		height: 720,
 	},
 };
 const Conference: React.FC<{conference: string}> = ({conference}) => {

--- a/pages/conferences/[conferenceName].tsx
+++ b/pages/conferences/[conferenceName].tsx
@@ -81,6 +81,7 @@ const Template: Record<string, TalkTemplate> = {
 		component: AlpesCraft,
 		width: 1280,
 		height: 720,
+		durationInFrames: 200,
 	},
 };
 const Conference: React.FC<{conference: string}> = ({conference}) => {

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {Composition, Folder, staticFile} from 'remotion';
 import {Sponsor} from './sponsor/Sponsor';
 import {LyonJSLogo} from './components/LyonJSLogo';

--- a/src/conference/alpescraft/AlpesCraft.tsx
+++ b/src/conference/alpescraft/AlpesCraft.tsx
@@ -7,11 +7,6 @@ import {Mountains} from './Mountains';
 import {Logo} from './Logo';
 import {Speakers} from './Speakers';
 
-export interface Speaker {
-	picture: string;
-	name: string;
-}
-
 export interface AlpesCraftProps {
 	title: string;
 	date: string;

--- a/src/conference/alpescraft/AlpesCraft.tsx
+++ b/src/conference/alpescraft/AlpesCraft.tsx
@@ -7,6 +7,11 @@ import {Mountains} from './Mountains';
 import {Logo} from './Logo';
 import {Speakers} from './Speakers';
 
+export interface Speaker {
+	picture: string;
+	name: string;
+}
+
 export interface AlpesCraftProps {
 	title: string;
 	date: string;

--- a/src/conference/alpescraft/Title.tsx
+++ b/src/conference/alpescraft/Title.tsx
@@ -7,7 +7,7 @@ export const Title: React.FC<{
 }> = ({title, style}) => {
 	const frame = useCurrentFrame();
 
-	const fromTop = interpolate(frame, [0, 20], [-100, 370], {
+	const fromTop = interpolate(frame, [0, 20], [-100, 385], {
 		easing: Easing.elastic(1.2),
 		extrapolateRight: 'clamp',
 	});
@@ -18,7 +18,7 @@ export const Title: React.FC<{
 		<span
 			style={{
 				fontWeight: 900,
-				fontSize: '3rem',
+				fontSize: '2.6rem',
 				color: 'white',
 				position: 'absolute',
 				top: fromTop,


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

To make the template easy access and customisable for users.

## 🧑‍🔬 How did you make them?

I've added the configuration for AlpesCraft in `pages/conferences/[conferenceName].tsx`.
I've also rebase from #156 to get the duration in frames for the composition

## 🧪 How to check them?

- You can run `pnpm dev` and go on the `conference` page, you should see a link on the list with the name **AlpesCraft**
- If you click on the link you should see the composition playing with the default data
