### PR TITLE
feat(talks|meetups): add dynamic event logo possibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
 	"description": "My Remotion video",
 	"repository": {},
 	"license": "MIT",
-	"main": "./src/index.tsx",
 	"scripts": {
 		"start": "remotion preview ./src/index.tsx",
 		"upgrade": "remotion upgrade",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"description": "My Remotion video",
 	"repository": {},
 	"license": "MIT",
+	"main": "./src/index.tsx",
 	"scripts": {
 		"start": "remotion preview ./src/index.tsx",
 		"upgrade": "remotion upgrade",

--- a/pages/meetup.tsx
+++ b/pages/meetup.tsx
@@ -6,11 +6,12 @@ import {Form, Input} from '../src/components/site/forms/input';
 
 const Home = () => {
 	const [title, setTitle] = useInputChange<string>('Example');
+	const [eventLogo, setEventLogo] = useInputChange<string>('');
 	const [date, setDate] = useInputChange<string>('28 septembre 2022');
 	const [backgroundImg, setBackgroundImg] = useInputChange<string | undefined>(
 		undefined
 	);
-	const props = {title, date, backgroundImg};
+	const props = {title, date, backgroundImg, eventLogo};
 
 	return (
 		<>
@@ -35,10 +36,17 @@ const Home = () => {
 				<Form>
 					<Input setValue={setTitle} value={title} label="SpeakerName" />
 					<Input setValue={setDate} value={date} label="Date" />
+
 					<Input
 						setValue={setBackgroundImg}
 						value={backgroundImg}
 						label="Background image url"
+					/>
+					<Input
+						setValue={setEventLogo}
+						value={eventLogo}
+						label="Event Logo (optional)"
+						placeholder="e.g: https://avatars.githubusercontent.com/u/929689?s=200&v=4"
 					/>
 					<a
 						className="text-black py-2 px-4 text-center text-xl font-bold bg-yellow-300 rounded-xl mt-4 hover:scale-105"

--- a/pages/talk.tsx
+++ b/pages/talk.tsx
@@ -10,6 +10,7 @@ const Talk = () => {
 		string | undefined
 	>(undefined);
 	const [speakersNames, setSpeakersNames] = useInputChange<string>('John Doe');
+	const [eventLogo, setEventLogo] = useInputChange<string>('');
 	const [titleSize, setTitleSize] = useInputChange<string>('50');
 	const [backgroundImg, setBackgroundImg] = useInputChange<string | undefined>(
 		undefined
@@ -20,6 +21,7 @@ const Talk = () => {
 		speakerPicture,
 		titleSize,
 		backgroundImg,
+		eventLogo,
 	};
 
 	return (
@@ -67,6 +69,12 @@ const Talk = () => {
 						setValue={setBackgroundImg}
 						value={backgroundImg}
 						label="Background Image"
+					/>
+					<Input
+						setValue={setEventLogo}
+						value={eventLogo}
+						label="Event Logo (optional)"
+						placeholder="e.g: https://avatars.githubusercontent.com/u/929689?s=200&v=4"
 					/>
 					<a
 						className="text-black py-2 px-4 text-center text-xl font-bold bg-yellow-300 rounded-xl mt-4 hover:scale-105"

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Composition, Folder, staticFile} from 'remotion';
 import {Sponsor} from './sponsor/Sponsor';
-import {LyonJSLogo} from './components/LyonJSLogo';
+import {EventLogo} from './components/EventLogo';
 import {ImageBackground} from './components/ImageBackground';
 import {Title} from './components/Title';
 import {Talk} from './talk/Talk';
@@ -41,10 +41,10 @@ export const RemotionVideo: React.FC = () => {
 					}}
 				/>
 				<Composition
-					component={LyonJSLogo}
+					component={EventLogo}
 					width={1200}
 					height={1200}
-					id="LyonJSLogo"
+					id="EventLogo"
 					fps={30}
 					durationInFrames={120}
 				/>

--- a/src/components/EventLogo.tsx
+++ b/src/components/EventLogo.tsx
@@ -1,0 +1,15 @@
+import {CSSProperties} from 'react';
+import {Img, staticFile} from 'remotion';
+
+export interface EventLogoProps {
+	style?: CSSProperties;
+	src?: string;
+}
+
+export const EventLogo = ({style, src}: EventLogoProps) => {
+	return src ? (
+		<Img style={style} src={src} />
+	) : (
+		<Img style={style} src={staticFile('/lyonjs-squared.png')} />
+	);
+};

--- a/src/components/LyonJSLogo.tsx
+++ b/src/components/LyonJSLogo.tsx
@@ -1,6 +1,0 @@
-import {CSSProperties} from 'react';
-import {Img, staticFile} from 'remotion';
-
-export const LyonJSLogo: React.FC<{style?: CSSProperties}> = ({style}) => (
-	<Img style={style} src={staticFile('/lyonjs-squared.png')} />
-);

--- a/src/components/site/Header.tsx
+++ b/src/components/site/Header.tsx
@@ -1,9 +1,9 @@
-import {LyonJSLogo} from '../LyonJSLogo';
+import {EventLogo} from '../EventLogo';
 
 export const Header: React.FC = () => {
 	return (
 		<header className="flex items-center my-9">
-			<LyonJSLogo style={{height: '60px', display: 'block'}} />
+			<EventLogo style={{height: '60px', display: 'block'}} />
 			<h1 className="text-2xl md:text-3xl ml-5">Social video generator</h1>
 			<a
 				className="ml-auto border-2 px-4 py-2 rounded-md hover:bg-white hover:text-black transition-all duration-200 font-bold"

--- a/src/components/site/forms/input.tsx
+++ b/src/components/site/forms/input.tsx
@@ -8,11 +8,14 @@ export const Form: React.FC<{children: ReactNode}> = ({children}) => {
 	);
 };
 
-export const Input: React.FC<{
+export interface InputProps {
 	value?: string;
 	setValue: (event: FormEvent<HTMLInputElement>) => void;
 	label: string;
-}> = ({value, setValue, label}) => {
+	placeholder?: string;
+}
+
+export const Input = ({value, setValue, label, placeholder}: InputProps) => {
 	return (
 		<label
 			style={{
@@ -34,6 +37,7 @@ export const Input: React.FC<{
 					borderRadius: '5px',
 					border: 'none',
 				}}
+				placeholder={placeholder}
 				onChange={setValue}
 			/>
 		</label>

--- a/src/meetup/Meetup.tsx
+++ b/src/meetup/Meetup.tsx
@@ -4,11 +4,19 @@ import {MeetupPresentation} from './MeetupPresentation';
 import {Register} from './Register';
 import {MeetupDate} from './MeetupDate';
 
-export const Meetup: React.FC<{
+export interface MeetupProps {
+	eventLogo?: string;
 	backgroundImg?: string;
 	title: string;
 	date?: string;
-}> = ({backgroundImg, title, date}) => {
+}
+
+export const Meetup = ({
+	backgroundImg,
+	title,
+	date,
+	eventLogo,
+}: MeetupProps) => {
 	return (
 		<AbsoluteFill
 			style={{
@@ -18,7 +26,7 @@ export const Meetup: React.FC<{
 			<ImageBackground animated src={backgroundImg} />
 
 			<Sequence from={40} durationInFrames={130}>
-				<MeetupPresentation title={title} />
+				<MeetupPresentation title={title} eventLogo={eventLogo} />
 			</Sequence>
 			{date && (
 				<Sequence from={120}>

--- a/src/meetup/MeetupLogo.tsx
+++ b/src/meetup/MeetupLogo.tsx
@@ -1,9 +1,12 @@
 import {AbsoluteFill, spring, useCurrentFrame, useVideoConfig} from 'remotion';
-import {LyonJSLogo} from '../components/LyonJSLogo';
+import {EventLogo} from '../components/EventLogo';
 
-export const MeetupLogo: React.FC<{endAnimationShift: number}> = ({
-	endAnimationShift,
-}) => {
+export interface MeetupLogoProps {
+	eventLogo?: string;
+	endAnimationShift: number;
+}
+
+export const MeetupLogo = ({eventLogo, endAnimationShift}: MeetupLogoProps) => {
 	const frame = useCurrentFrame();
 	const {fps} = useVideoConfig();
 
@@ -38,7 +41,8 @@ export const MeetupLogo: React.FC<{endAnimationShift: number}> = ({
 
 	return (
 		<AbsoluteFill style={{display: 'flex', alignItems: 'center'}}>
-			<LyonJSLogo
+			<EventLogo
+				src={eventLogo}
 				style={{
 					position: 'absolute',
 					top: 150,

--- a/src/meetup/MeetupPresentation.tsx
+++ b/src/meetup/MeetupPresentation.tsx
@@ -2,12 +2,20 @@ import {AbsoluteFill} from 'remotion';
 import {MeetupTitle} from './MeetupTitle';
 import {MeetupLogo} from './MeetupLogo';
 
-export const MeetupPresentation: React.FC<{title: string}> = ({title}) => {
+export interface MeetupPresentationProps {
+	eventLogo?: string;
+	title: string;
+}
+
+export const MeetupPresentation = ({
+	title,
+	eventLogo,
+}: MeetupPresentationProps) => {
 	const endAnimationShift = 50;
 
 	return (
 		<AbsoluteFill style={{display: 'flex', alignItems: 'center'}}>
-			<MeetupLogo endAnimationShift={endAnimationShift} />
+			<MeetupLogo endAnimationShift={endAnimationShift} eventLogo={eventLogo} />
 			<MeetupTitle title={title} endAnimationShift={endAnimationShift} />
 		</AbsoluteFill>
 	);

--- a/src/sponsor/SponsorOrgaLogo.tsx
+++ b/src/sponsor/SponsorOrgaLogo.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {LyonJSLogo} from '../components/LyonJSLogo';
+import {EventLogo} from '../components/EventLogo';
 import {interpolate, spring, useCurrentFrame, useVideoConfig} from 'remotion';
 
 export const SponsorOrgaLogo: React.FC = () => {
@@ -18,7 +18,7 @@ export const SponsorOrgaLogo: React.FC = () => {
 	});
 
 	return (
-		<LyonJSLogo
+		<EventLogo
 			style={{
 				position: 'absolute',
 				bottom: 60,

--- a/src/talk/Talk.tsx
+++ b/src/talk/Talk.tsx
@@ -1,16 +1,18 @@
 import {AbsoluteFill, Sequence} from 'remotion';
 import {ImageBackground} from '../components/ImageBackground';
-import {LyonJSLogo} from '../components/LyonJSLogo';
+import {EventLogo} from '../components/EventLogo';
 import {TalkSpeakerPicture} from './TalkSpeakerPicture';
 import {TalkTitles} from './TalkTitles';
 
 export const Talk: React.FC<{
+	eventLogo?: string;
 	speakersNames: string;
 	talkTitle: string;
 	backgroundImg?: string;
 	speakerPicture?: string;
 	titleSize?: string;
 }> = ({
+	eventLogo,
 	speakersNames,
 	talkTitle,
 	speakerPicture,
@@ -39,7 +41,8 @@ export const Talk: React.FC<{
 					/>
 				</Sequence>
 
-				<LyonJSLogo
+				<EventLogo
+					src={eventLogo}
 					style={{
 						position: 'absolute',
 						bottom: 30,


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

Open the project to other meetups by allowing them to use their logo instead of the LyonJs's one

## 🧑‍🔬 How did you make them?

Add an input field in the Talk and Meetup generation page where people can add a static URL (fallback to LyonJs logo if not present)

## 🧪 How to check them?

- Go to `/meetup` and fill the last input value with a valid image URL
- (Optionnally) generate the video

Do the same for `/talks` :)


## Screenshots:

<img width="890" alt="Screenshot 2023-03-05 at 8 54 53 AM" src="https://user-images.githubusercontent.com/3874873/222948769-40a1d997-f12b-4fe6-9cb3-bcf5a807c7f1.png">
