### PR TITLE
feat(lyonjs): add title for layers

### DIFF
--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -327,12 +327,18 @@ export const RemotionVideo: React.FC = () => {
 					<Still
 						id="LyonJSLayerOneSpeaker"
 						component={LayerOneSpeaker}
+						defaultProps={{
+							title: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit',
+						}}
 						width={1920}
 						height={1080}
 					/>
 					<Still
 						id="LyonJSLayerTwoSpeaker"
 						component={LayerTwoSpeaker}
+						defaultProps={{
+							title: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit',
+						}}
 						width={1920}
 						height={1080}
 					/>

--- a/src/conference/lyonJS/GreenScreen.tsx
+++ b/src/conference/lyonJS/GreenScreen.tsx
@@ -11,6 +11,7 @@ export const GreenScreen: React.FC<{style?: React.CSSProperties}> = ({
 				aspectRatio: '16/9',
 				border: '10px solid white',
 				backgroundColor: 'green',
+				flexShrink: '0',
 				...style,
 			}}
 		/>

--- a/src/conference/lyonJS/LayerOneSpeaker.tsx
+++ b/src/conference/lyonJS/LayerOneSpeaker.tsx
@@ -3,8 +3,10 @@ import React from 'react';
 import {RightTriangle} from './RightTriangle';
 import {LeftTriangle} from './LeftTriangle';
 import {GreenScreen} from './GreenScreen';
+import {LayerTitle} from './LayerTitle';
 
-export const LayerOneSpeaker: React.FC = () => {
+type Props = {title: string};
+export const LayerOneSpeaker: React.FC<Props> = ({title}) => {
 	return (
 		<AbsoluteFill style={{backgroundColor: 'white', overflow: 'hidden'}}>
 			<RightTriangle />
@@ -26,6 +28,13 @@ export const LayerOneSpeaker: React.FC = () => {
 					position: 'absolute',
 					bottom: 0,
 					right: 0,
+				}}
+			/>
+			<LayerTitle
+				title={title}
+				style={{
+					width: 'calc(70% - 30px)',
+					marginTop: '-30px',
 				}}
 			/>
 		</AbsoluteFill>

--- a/src/conference/lyonJS/LayerTitle.tsx
+++ b/src/conference/lyonJS/LayerTitle.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import {loadFont} from '@remotion/google-fonts/Aldrich';
+
+const {fontFamily} = loadFont();
+
+type Props = {
+	title: string;
+	style?: React.CSSProperties;
+};
+
+export const LayerTitle: React.FC<Props> = ({title, style}) => {
+	return (
+		<div
+			style={{
+				fontFamily,
+				fontWeight: 900,
+				fontSize: '38px',
+				color: 'white',
+				textAlign: 'center',
+				zIndex: '2',
+				flex: '1',
+				padding: '30px',
+				display: 'flex',
+				flexDirection: 'column',
+				alignItems: 'center',
+				justifyContent: 'center',
+				lineHeight: '52px',
+				...style,
+			}}
+		>
+			{title}
+		</div>
+	);
+};

--- a/src/conference/lyonJS/LayerTwoSpeaker.tsx
+++ b/src/conference/lyonJS/LayerTwoSpeaker.tsx
@@ -3,8 +3,10 @@ import React from 'react';
 import {RightTriangle} from './RightTriangle';
 import {LeftTriangle} from './LeftTriangle';
 import {GreenScreen} from './GreenScreen';
+import {LayerTitle} from './LayerTitle';
 
-export const LayerTwoSpeaker: React.FC = () => {
+type Props = {title: string};
+export const LayerTwoSpeaker: React.FC<Props> = ({title}) => {
 	return (
 		<AbsoluteFill style={{backgroundColor: 'white', overflow: 'hidden'}}>
 			<RightTriangle />
@@ -28,6 +30,16 @@ export const LayerTwoSpeaker: React.FC = () => {
 			>
 				<GreenScreen style={{width: '50%', margin: 20}} />
 				<GreenScreen style={{width: '50%', margin: 20}} />
+			</div>
+			<div
+				style={{
+					zIndex: 2,
+					flex: 1,
+					display: 'flex',
+					width: '70%',
+				}}
+			>
+				<LayerTitle title={title} />
 			</div>
 		</AbsoluteFill>
 	);


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

If could be could if the Layers can have a title as prop

## 🧑‍🔬 How did you make them?

I only add title for layer with one or two speakers, in full screen there is no space available for title.

<img width="1430" alt="image" src="https://user-images.githubusercontent.com/7687610/223792755-a4d68dcb-cd5c-446c-b0a2-9610ef2cb512.png">

<img width="1430" alt="image" src="https://user-images.githubusercontent.com/7687610/223792715-9cf65ee4-1b03-4d71-a207-c1c0cc1eff83.png">

<img width="1430" alt="image" src="https://user-images.githubusercontent.com/7687610/223792674-24fa27af-8a17-4c9d-8432-19d6789b403f.png">

