### PR TITLE
feat(lyonjs): add page to display layer in fullscreen

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -7,6 +7,9 @@ import {Header} from '../src/components/site/Header';
 import {NavBar} from '../src/components/site/NavBar';
 
 export default ({Component, pageProps}) => {
+	if (Component.noLayout) {
+		return <Component {...pageProps} />;
+	}
 	return (
 		<main className="mx-auto p-4">
 			<Head>

--- a/pages/layer/fullscreen.tsx
+++ b/pages/layer/fullscreen.tsx
@@ -1,0 +1,50 @@
+import {Player} from '@remotion/player';
+import {LayerOneSpeaker} from '../../src/conference/lyonJS/LayerOneSpeaker';
+import {LayerTwoSpeaker} from '../../src/conference/lyonJS/LayerTwoSpeaker';
+import {LayerFullScreen} from '../../src/conference/lyonJS/LayerFullScreen';
+import React from 'react';
+import {useSearchParams} from 'next/navigation';
+
+type LayerMode = 'one' | 'two' | 'full';
+
+const LayerByMode: React.FC<{mode: LayerMode; title: string}> = ({
+	mode,
+	title,
+}) => {
+	switch (mode) {
+		case 'two':
+			return <LayerTwoSpeaker title={title} />;
+		case 'full':
+			return <LayerFullScreen />;
+		case 'one':
+		default:
+			return <LayerOneSpeaker title={title} />;
+	}
+};
+
+const Fullscreen = () => {
+	const params = useSearchParams();
+	const title = params.get('title') || '';
+	const mode = params.get('mode') as LayerMode;
+
+	console.log('render');
+
+	return (
+		<Player
+			style={{
+				width: '100%',
+				aspectRatio: '16 / 9',
+			}}
+			durationInFrames={1}
+			compositionWidth={1920}
+			compositionHeight={1080}
+			fps={30}
+			inputProps={{title, mode}}
+			component={LayerByMode}
+		/>
+	);
+};
+
+Fullscreen.noLayout = true;
+
+export default Fullscreen;

--- a/pages/layer/fullscreen.tsx
+++ b/pages/layer/fullscreen.tsx
@@ -27,8 +27,6 @@ const Fullscreen = () => {
 	const title = params.get('title') || '';
 	const mode = params.get('mode') as LayerMode;
 
-	console.log('render');
-
 	return (
 		<Player
 			style={{

--- a/src/conference/lyonJS/GreenScreen.tsx
+++ b/src/conference/lyonJS/GreenScreen.tsx
@@ -10,7 +10,7 @@ export const GreenScreen: React.FC<{style?: React.CSSProperties}> = ({
 				margin: 30,
 				aspectRatio: '16/9',
 				border: '10px solid white',
-				backgroundColor: 'green',
+				backgroundColor: '#00FF00',
 				flexShrink: '0',
 				...style,
 			}}


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

It could be could if we can directly point to an URL with query param for pages

## 🧑‍🔬 How did you make them?

I had en endpoint to `/layer/fullscreen` with two query params:
- `mode` which can be 'one', 'two' or 'full'
- `title` to display the title of the PR

I had to prevent default page layout by adding a property on the component `noLayout` directly, used on the _app.tsx directly

## 🧪 How to check them?

- https://social-video-generator-git-fullscreen-layers-lyonjs.vercel.app/layer/fullscreen?title=Project%20XState
- https://social-video-generator-git-fullscreen-layers-lyonjs.vercel.app/layer/fullscreen?title=Project%20XState&mode=two
- https://social-video-generator-git-fullscreen-layers-lyonjs.vercel.app/layer/fullscreen?title=Project%20XState&mode=full
