### PR TITLE
chore(remotion): reorganise remotion preview to fit project organisation

### DIFF
--- a/remotion/Video.tsx
+++ b/remotion/Video.tsx
@@ -8,10 +8,8 @@ import {AtomsComposition} from './design/atoms/Atoms.composition';
 export const RemotionVideo: React.FC = () => {
 	return (
 		<>
-			<Folder name="Compositions">
-				<TemplatesComposition />
-				<ShowcasesComposition />
-			</Folder>
+			<TemplatesComposition />
+			<ShowcasesComposition />
 			<Folder name="Design">
 				<AtomsComposition />
 			</Folder>

--- a/remotion/Video.tsx
+++ b/remotion/Video.tsx
@@ -1,13 +1,20 @@
 import React from 'react';
 
+import {Folder} from 'remotion';
 import {ShowcasesComposition} from './compositions/showcases/Showcases.composition';
 import {TemplatesComposition} from './compositions/templates/Templates.composition';
+import {AtomsComposition} from './design/atoms/Atoms.composition';
 
 export const RemotionVideo: React.FC = () => {
 	return (
 		<>
-			<TemplatesComposition />
-			<ShowcasesComposition />
+			<Folder name="Compositions">
+				<TemplatesComposition />
+				<ShowcasesComposition />
+			</Folder>
+			<Folder name="Design">
+				<AtomsComposition />
+			</Folder>
 		</>
 	);
 };

--- a/remotion/compositions/templates/Templates.composition.tsx
+++ b/remotion/compositions/templates/Templates.composition.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {Folder} from 'remotion';
 
-import {AtomsComposition} from '../../design/atoms/Atoms.composition';
 import {SponsorsComposition} from './sponsor/Sponsors.composition';
 import {TalksComposition} from './talk/Talks.composition';
 import {MeetupComposition} from './meetup/Meetup.composition';
@@ -10,7 +9,6 @@ import {EventsComposition} from './event/Events.composition';
 export const TemplatesComposition: React.FC = () => {
 	return (
 		<Folder name="Templates">
-			<AtomsComposition />
 			<SponsorsComposition />
 			<TalksComposition />
 			<MeetupComposition />


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

The remotion preview don't have the same folder management as in the project. It will be better to find the components if both organisations match.

## 🧑‍🔬 How did you make them?

I've updated the file `remotion/video.tsx` and split in folder the imports following the project organisation.

## 🧪 How to check them?

- You can run `pnpm start` and compare the organisation with the one in the project.
