### PR TITLE
fix(showcases): fix alpescraft video

### DIFF
--- a/remotion/compositions/showcases/alpescraft/AlpesCraft.tsx
+++ b/remotion/compositions/showcases/alpescraft/AlpesCraft.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {AbsoluteFill, Sequence, staticFile} from 'remotion';
-import {Title} from './Title';
+import {TalkTitle} from './TalkTitle';
 import {Details} from './Details';
 import {ImageBackground} from '../../../design/atoms/ImageBackground';
 import {Mountains} from './Mountains';
@@ -47,7 +47,7 @@ export const AlpesCraft: React.FC<AlpesCraftProps> = ({
 				<Mountains />
 			</Sequence>
 			<Sequence name="Logo-&-title" from={30}>
-				<Title title={title} />
+				<TalkTitle title={title} />
 				{speakers ? <Speakers speakers={speakers} /> : <Logo />}
 			</Sequence>
 			<Sequence name="Details" from={60}>

--- a/remotion/compositions/showcases/alpescraft/Speakers.tsx
+++ b/remotion/compositions/showcases/alpescraft/Speakers.tsx
@@ -9,6 +9,7 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
+import {Text} from '../../../design/atoms/Text';
 
 export const Speakers: React.FC<{speakers: Speaker[]}> = ({speakers}) => {
 	const frame = useCurrentFrame();
@@ -57,16 +58,20 @@ export const Speakers: React.FC<{speakers: Speaker[]}> = ({speakers}) => {
 								borderRadius: '50% 20% / 10% 40%',
 								top: pictureDrop,
 							}}
-							captionStyle={{
-								position: 'relative',
-								marginTop: 0,
-								fontSize: 30,
-								textShadow: `0 0 20px #00000099`,
-								top: nameAppear,
-								opacity: nameOpacity,
-							}}
 						>
-							<SpeakersName name={speaker.name} />
+							<Text
+								style={{
+									position: 'relative',
+									marginTop: 0,
+									fontSize: 30,
+									fontWeight: 'bold',
+									textShadow: `0 0 20px #00000099`,
+									top: nameAppear,
+									opacity: nameOpacity,
+								}}
+							>
+								<SpeakersName name={speaker.name} />
+							</Text>
 						</AvatarWithCaption>
 					</div>
 				);

--- a/remotion/compositions/showcases/alpescraft/TalkTitle.tsx
+++ b/remotion/compositions/showcases/alpescraft/TalkTitle.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import {Easing, interpolate, useCurrentFrame} from 'remotion';
+import {Title} from '../../../design/atoms/Title';
 
-export const Title: React.FC<{
+export const TalkTitle: React.FC<{
 	title: string;
-	style?: React.CSSProperties;
-}> = ({title, style}) => {
+}> = ({title}) => {
 	const frame = useCurrentFrame();
 
 	const fromTop = interpolate(frame, [0, 20], [-100, 385], {
@@ -15,26 +15,19 @@ export const Title: React.FC<{
 	const titleOpacity = interpolate(frame, [5, 15], [0, 1]);
 
 	return (
-		<span
+		<Title
 			style={{
-				fontWeight: 900,
 				fontSize: '2.6rem',
 				color: 'white',
 				position: 'absolute',
 				top: fromTop,
-				width: '100%',
-				height: '130px',
 				padding: '0 95px',
 				textAlign: 'center',
 				textShadow: '`1px 1px 3px white`',
-				display: 'flex',
-				justifyContent: 'center',
-				alignItems: 'center',
 				opacity: titleOpacity,
-				...style,
 			}}
 		>
 			{title}
-		</span>
+		</Title>
 	);
 };


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

By updating the title with the text atom, the showcases must be updated too with the good uses. If not the compositions should be broken in some points (speakers name)

## 🧑‍🔬 How did you make them?

i've updated the Alpescraft composition with the atom text

## 🧪 How to check them?

- In the preview, nothing should be different than before
